### PR TITLE
Add instrument name to the card description

### DIFF
--- a/hugin/run_monitor.py
+++ b/hugin/run_monitor.py
@@ -27,6 +27,7 @@ class RunMonitor(Monitor):
         assert self.trello_board is not None, "Could not locate run tracking board in Trello"
         self.run_folders = [d.strip() for d in config.get("run_folders","").split(",")]
         self.samplesheet_folders = [d.strip() for d in config.get("samplesheet_folders","").split(",")]
+        self.instruments = config.get("instruments", {})
         
     def set_run_completed(self, run):
         """Set the status of the run to completed"""
@@ -194,7 +195,12 @@ class RunMonitor(Monitor):
         metadata['Projects'] = run['projects']
         metadata['Setup'] = self.get_run_setup(run) 
         metadata['Flowcell'] = run['run_info'].get('Flowcell','NA')
-        metadata['Instrument'] = run['run_info'].get('Instrument','NA')
+        instrument = run['run_info'].get('Instrument','NA')
+        if self.instruments:
+            instrument_name = self.instruments.get(instrument, '')
+            if instrument_name:
+                instrument += " ({name})".format(name=instrument_name)
+        metadata['Instrument'] = instrument
         metadata['Date'] = run['run_info'].get('Date','NA')      
         metadata['Run mode'] = run['run_parameters'].get('RunMode','HighOutput' if not self.is_miseq_run(run) else 'MiSeq')  
         return metadata


### PR DESCRIPTION
This pull request adds the instrument name to the card description on Trello. The instrument name is matched using the instrument ID (the dictionary Instrument ID --> Instrument name is stored in a configuration file).
