### PR TITLE
small fix in merging description

### DIFF
--- a/hugin/monitor.py
+++ b/hugin/monitor.py
@@ -160,9 +160,9 @@ class Monitor(object):
         
         if merge:
             current = self.description_to_dict(card.description)
-            current.update(description)
             if cmp(current, description) == 0:
                 return False
+            current.update(description)
             description = current
         
         # Convert the description dict to a string that will be formatted as a list


### PR DESCRIPTION
Sorry for lot of small fixes, as just modifying the existing code I presumed it is not necessary to test the old blocks. 

this fix, as always 'description' and 'current' will have same 'keys', after updating either of them with other i.e. current.update(description) or description.update(current) will overwrite the other dictionary (as the keys are always same). So eventually, will always be 'cmp(current, description) == 0' and return False. 
